### PR TITLE
Expose capture and analysis lifecycle contracts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["<rootDir>/test/**/*.test.ts"],
+  modulePathIgnorePatterns: ["<rootDir>/build/"],
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@facesignai/api",
   "package-name": "@facesignai/api",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "Facesign API wrapper",
   "repository": {
     "type": "git",

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -109,6 +109,13 @@ export type SessionReportAIAnalysis = {
   analysis: SessionReportAIAnalysisSection[]
 }
 
+export type VideoAIAnalysisStatus =
+  | "notRequested"
+  | "pending"
+  | "completed"
+  | "failed"
+  | "timedOut"
+
 export interface SessionMedia {
   id: string
   createdAt: number
@@ -131,6 +138,7 @@ export interface SessionReport {
   lang?: string
   nodeReports?: NodeReport[]
   videoAIAnalysis?: VideoAIAnalysis
+  videoAIAnalysisStatus?: VideoAIAnalysisStatus
   extractedData?: ExtractedData
   media?: {
     screenshots?: SessionMedia[]

--- a/src/types/nodeReports.ts
+++ b/src/types/nodeReports.ts
@@ -11,6 +11,8 @@ import {
   FSFaceCompareOutcome,
 } from "./nodes"
 
+// cspell:ignore Unscored
+
 import { DocumentScanReport } from "./docScanning"
 
 export type NodeReportBase = {
@@ -90,6 +92,10 @@ export type EnterEmailNodeReport = NodeReportBase & {
 export type LivenessDetectionNodeReport = NodeReportBase & {
   type: FSNodeType.LIVENESS_DETECTION
   outcome: FSLivenessDetectionOutcome
+  screenshotCount?: number
+  captureStatus?: "captured" | "capturedUnscored" | "unavailable"
+  errored?: boolean
+  errorCode?: string
 }
 
 export type ConversationNodeReport = NodeReportBase & {

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -63,7 +63,13 @@ export enum FSLivenessDetectionOutcome {
   LIVENESS_DETECTED = "livenessDetected",
   DEEPFAKE_DETECTED = "deepfakeDetected",
   NO_FACE = "noFace",
+  CAPTURE_UNAVAILABLE = "captureUnavailable",
 }
+
+type RequiredLivenessDetectionOutcome = Exclude<
+  FSLivenessDetectionOutcome,
+  FSLivenessDetectionOutcome.CAPTURE_UNAVAILABLE
+>
 
 /**
  * Checks whether the user is a real person or a deepfake by analyzing the video feed.
@@ -76,7 +82,8 @@ export enum FSLivenessDetectionOutcome {
  */
 export interface FSLivenessDetectionNode extends FSNodeBase {
   type: FSNodeType.LIVENESS_DETECTION
-  outcomes: Record<FSLivenessDetectionOutcome, FSNodeId>
+  outcomes: Record<RequiredLivenessDetectionOutcome, FSNodeId> &
+    Partial<Record<FSLivenessDetectionOutcome.CAPTURE_UNAVAILABLE, FSNodeId>>
 }
 
 export enum FSEnterEmailOutcome {

--- a/test/liveness-contracts.test.ts
+++ b/test/liveness-contracts.test.ts
@@ -1,0 +1,49 @@
+import {
+  FSLivenessDetectionNode,
+  FSLivenessDetectionOutcome,
+  FSNodeType,
+  LivenessDetectionNodeReport,
+  VideoAIAnalysisStatus,
+} from "../src/api-endpoints"
+
+const legacyNode: FSLivenessDetectionNode = {
+  id: "liveness",
+  type: FSNodeType.LIVENESS_DETECTION,
+  outcomes: {
+    [FSLivenessDetectionOutcome.LIVENESS_DETECTED]: "pass",
+    [FSLivenessDetectionOutcome.DEEPFAKE_DETECTED]: "deny",
+    [FSLivenessDetectionOutcome.NO_FACE]: "retry",
+  },
+}
+
+const versionedNode: FSLivenessDetectionNode = {
+  ...legacyNode,
+  outcomes: {
+    ...legacyNode.outcomes,
+    [FSLivenessDetectionOutcome.CAPTURE_UNAVAILABLE]: "platform-error",
+  },
+}
+
+describe("liveness contracts", () => {
+  it("keeps the capture-unavailable edge optional for legacy flows", () => {
+    expect(legacyNode.outcomes.captureUnavailable).toBeUndefined()
+    expect(versionedNode.outcomes.captureUnavailable).toBe("platform-error")
+  })
+
+  it("exposes diagnosable unavailable reports and analysis states", () => {
+    const report: LivenessDetectionNodeReport = {
+      type: FSNodeType.LIVENESS_DETECTION,
+      nodeId: "liveness",
+      createdAt: Date.now(),
+      outcome: FSLivenessDetectionOutcome.CAPTURE_UNAVAILABLE,
+      screenshotCount: 0,
+      captureStatus: "unavailable",
+      errored: true,
+      errorCode: "SOURCE_UNAVAILABLE",
+    }
+    const status: VideoAIAnalysisStatus = "pending"
+
+    expect(report.captureStatus).toBe("unavailable")
+    expect(status).toBe("pending")
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "forceConsistentCasingInFileNames": true,
     "typeRoots": ["./node_modules/@types"]
-  }
+  },
 
-  // "include": ["src/**/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary

- add public capture/analysis lifecycle declarations and node-report fields
- expose the related API endpoint contract
- add focused contract tests
- prepare version `1.0.42` without publishing it

## Why

The old contract could not distinguish a capture pipeline outage from a real `noFace` result or represent analysis that legitimately completes after the FaceSign session. Downstream services need explicit, typed states to retry safely and fail closed at a bounded deadline.

## Impact

This unblocks the coordinated Socket and FF fixes. No npm package was published and no environment was changed.

## Validation

- `npm test -- --runInBand`: passed
- `npm run build`: passed
- `npm pack --dry-run`: passed and included the new declarations

## Required release gate

Only Maksim may merge and publish `@facesignai/api@1.0.42`. The FF PR must remain blocked until the real registry artifact exists, its lockfile is regenerated, and clean `npm ci` plus tests pass.