### PR TITLE
feat(api): captionsOpenedByDefault + inconclusive liveness outcome (1.0.44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the Facesign API will be documented in this file.
 
+## [1.0.44] - 2026-08-05
+
+### Breaking
+
+- `FSLivenessDetectionOutcome` gains a fourth member, `INCONCLUSIVE` (`"inconclusive"`).
+  Because `FSLivenessDetectionNode.outcomes` is `Record<FSLivenessDetectionOutcome, FSNodeId>`,
+  **every flow builder on this version must supply the `inconclusive` edge** — code that
+  builds a liveness node with only the three previous outcomes no longer type-checks.
+  An inconclusive check means the detector produced no verdict (it could not decide, did
+  not run, or there was nothing to analyze); it is a failure of the check, not of the user,
+  and where it routes is now your decision instead of ours.
+
+  Flows submitted without the edge are still accepted at runtime: the missing outcome is
+  filled with the node's `noFace` target, recorded in `SessionSettings.flowNormalizations`
+  and reported in `CreateSessionResponse.warnings`. Treat that as a migration aid, not as
+  the answer — a filled edge is our guess, not the flow author's decision.
+
+### Added
+
+- `ControlsCustomization.captionsOpenedByDefault` — optional. `true` opens the transcript
+  (closed-captions) panel at session start; omitted or `false` keeps today's closed state.
+  The user can still toggle the panel with the CC button either way. Ignored when
+  `showUxControls` is `false`, which is the master switch for the whole control panel.
+- `LivenessDetectionNodeReport.inconclusiveReason` and the `LivenessInconclusiveReason`
+  type (`"no_media" | "unusable_media" | "unknown_verdict" | "timeout" | "provider_error"`),
+  set only when the node outcome is `inconclusive`.
+- `DeepfakeDetectionStatus` and `SessionReport.deepfakeDetectionStatus` —
+  `pending | succeeded | failed | timed_out` plus `startedAt` / `finishedAt` / `errorCode`.
+  This distinguishes "the post-session analysis ran and found nothing" from "the analysis
+  never produced a result". Absent when the analysis was not requested.
+- `WebhookType.ANALYSIS_DEEPFAKE` (`"analysis.deepfake"`) — fired when post-session deepfake
+  analysis reaches a terminal state. Doorbell-only: refetch the session for the verdict.
+- `SessionSettings.flowNormalizations` (read-only) and `CreateSessionResponse.warnings`.
+
 ## [1.0.41] - 2026-05-14
 
 ### Added

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["<rootDir>/test/**/*.test.ts"],
+  // build/ holds a copy of package.json; without this jest reports a haste collision.
+  modulePathIgnorePatterns: ["<rootDir>/build/"],
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@facesignai/api",
   "package-name": "@facesignai/api",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "description": "Facesign API wrapper",
   "repository": {
     "type": "git",

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -1,10 +1,13 @@
 import { Device } from "./types/deviceDetails"
 import { Location } from "./types/location"
-import { FSNode } from "./types/nodes"
+import { FSNode, FSNodeId } from "./types/nodes"
 import { Customization } from "./types/customization"
 import { NodeReport } from "./types/nodeReports"
 import { VideoAIAnalysis } from "./types/videoAIAnalysis"
-import { DeepfakeDetection } from "./types/deepfakeDetection"
+import {
+  DeepfakeDetection,
+  DeepfakeDetectionStatus,
+} from "./types/deepfakeDetection"
 
 export * from "./types/deviceDetails"
 export * from "./types/location"
@@ -134,6 +137,12 @@ export interface SessionReport {
   nodeReports?: NodeReport[]
   videoAIAnalysis?: VideoAIAnalysis
   deepfakeDetection?: DeepfakeDetection
+  /**
+   * Lifecycle of the post-session deepfake analysis. Absent when the analysis
+   * was not requested for this session. Tells "analysis succeeded and found
+   * nothing" apart from "analysis never produced a result".
+   */
+  deepfakeDetectionStatus?: DeepfakeDetectionStatus
   extractedData?: ExtractedData
   media?: {
     screenshots?: SessionMedia[]
@@ -195,11 +204,39 @@ export interface SessionSettings {
    * transcript using an LLM. Results are returned in `SessionReport.extractedData`.
    */
   extractionSchema?: ExtractionField[]
+  /**
+   * Read-only. Records outcome edges that were missing from the submitted flow
+   * and were filled in for you at session creation, so the stored graph is
+   * total. Present only when something was filled.
+   *
+   * A filled edge is our guess, not your decision — rebuild the flow with the
+   * edge wired explicitly. See `CreateSessionResponse.warnings`.
+   */
+  flowNormalizations?: FlowNormalization[]
+}
+
+/**
+ * One outcome edge that was absent from a submitted flow node and was filled
+ * in at session creation.
+ */
+export type FlowNormalization = {
+  /** The node whose `outcomes` map was incomplete. */
+  nodeId: FSNodeId
+  /** The outcome key that was missing. */
+  outcome: string
+  /** The node id it now points at. */
+  filledWith: FSNodeId
 }
 
 export interface CreateSessionResponse {
   session: Session
   clientSecret: ClientSecret
+  /**
+   * Non-fatal problems with the submitted flow. The session was created
+   * regardless. Currently emitted when an outcome edge was missing and had to
+   * be filled in — see `SessionSettings.flowNormalizations`.
+   */
+  warnings?: string[]
 }
 
 export const createSessionEndpoint = {

--- a/src/types/customization.ts
+++ b/src/types/customization.ts
@@ -1,6 +1,6 @@
 export enum BackgroundType {
-  AVATAR = 'AVATAR',
-  COLOR = 'COLOR',
+  AVATAR = "AVATAR",
+  COLOR = "COLOR",
 }
 
 export type PermissionsPageCustomization = {
@@ -15,7 +15,23 @@ export type PermissionsPageCustomization = {
 }
 
 export type ControlsCustomization = {
+  /**
+   * Master switch for the in-session control panel. When `false` the panel is
+   * not rendered at all, so every other `controls.*` setting — including
+   * `captionsOpenedByDefault` — is inapplicable and silently has no effect.
+   */
   showUxControls?: boolean
+  /**
+   * Initial state of the closed-captions (transcript) panel.
+   *
+   * Omitted or `false` — the panel starts closed (today's behaviour).
+   * `true` — the panel is open from the start of the session; the user can
+   * still close and reopen it with the CC button.
+   *
+   * Intended for accessibility and for users who are more comfortable reading
+   * along in a second language. Ignored when `showUxControls` is `false`.
+   */
+  captionsOpenedByDefault?: boolean
 }
 
 export type Customization = {

--- a/src/types/deepfakeDetection.ts
+++ b/src/types/deepfakeDetection.ts
@@ -13,3 +13,32 @@ export type DeepfakeDetection = {
   /** When the analysis completed (ms epoch). */
   analyzedAt?: number
 }
+
+/**
+ * Lifecycle of the post-session deepfake analysis, surfaced on the public
+ * session report (`SessionReport.deepfakeDetectionStatus`).
+ *
+ * This is what distinguishes "the analysis ran and found nothing" from "the
+ * analysis never produced a result". `deepfakeDetection` is present only in
+ * the former case; this field says which case you are in.
+ *
+ * The field is absent when the analysis was not requested for the session.
+ *
+ * Subscribe to the `analysis.deepfake` webhook to be told when the state goes
+ * terminal instead of polling for it.
+ */
+export type DeepfakeDetectionStatus = {
+  /**
+   * - `pending` — analysis is running.
+   * - `succeeded` — analysis produced a verdict; see `deepfakeDetection`.
+   * - `failed` — the analysis backend failed; see `errorCode`.
+   * - `timed_out` — the analysis did not finish in time.
+   */
+  state: "pending" | "succeeded" | "failed" | "timed_out"
+  /** When the analysis started (ms epoch). */
+  startedAt?: number
+  /** When the analysis reached a terminal state (ms epoch). */
+  finishedAt?: number
+  /** Machine-readable failure reason, set for `failed`. */
+  errorCode?: string
+}

--- a/src/types/nodeReports.ts
+++ b/src/types/nodeReports.ts
@@ -109,9 +109,28 @@ export type EnterEmailNodeReport = NodeReportBase & {
   email?: string
 }
 
+/**
+ * Why a liveness check produced no verdict. Only meaningful when the node
+ * outcome is `inconclusive`.
+ *
+ * - `no_media` — nothing was captured to analyze (camera denied or unavailable).
+ * - `unusable_media` — frames were captured but could not be analyzed.
+ * - `unknown_verdict` — the detector ran and reported that it cannot decide.
+ * - `timeout` — the analysis did not finish in time.
+ * - `provider_error` — the detection backend failed or was unavailable.
+ */
+export type LivenessInconclusiveReason =
+  | "no_media"
+  | "unusable_media"
+  | "unknown_verdict"
+  | "timeout"
+  | "provider_error"
+
 export type LivenessDetectionNodeReport = NodeReportBase & {
   type: FSNodeType.LIVENESS_DETECTION
   outcome: FSLivenessDetectionOutcome
+  /** Set only when `outcome` is `inconclusive`. */
+  inconclusiveReason?: LivenessInconclusiveReason
 }
 
 export type ConversationNodeReport = NodeReportBase & {

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -145,10 +145,23 @@ export interface FSConversationNode extends FSNodeBase {
   awaitExternal?: FSAwaitExternalConfig
 }
 
+/**
+ * The four possible results of a liveness check. The set is total and
+ * non-overlapping: every check ends in exactly one of them.
+ *
+ * - `livenessDetected` — a live person is in front of the camera.
+ * - `deepfakeDetected` — a spoof or manipulation was detected.
+ * - `noFace` — frames were captured, but no face is on them.
+ * - `inconclusive` — there is no verdict: the detector could not decide, did
+ *   not run, or there was nothing to analyze. This is a failure of the check,
+ *   not of the user — route it deliberately (a retry, a step-up, a manual
+ *   review or a stop), never to the happy path by default.
+ */
 export enum FSLivenessDetectionOutcome {
   LIVENESS_DETECTED = "livenessDetected",
   DEEPFAKE_DETECTED = "deepfakeDetected",
   NO_FACE = "noFace",
+  INCONCLUSIVE = "inconclusive",
 }
 
 /**
@@ -159,6 +172,12 @@ export enum FSLivenessDetectionOutcome {
  * in between to accumulate video data.
  *
  * Recommended flow order: PERMISSIONS → CONVERSATION → LIVENESS_DETECTION
+ *
+ * Every outcome must be wired: `outcomes` is a total map over
+ * `FSLivenessDetectionOutcome`, including `inconclusive`. An inconclusive
+ * check means the detector produced no verdict — the reason is reported in
+ * `LivenessDetectionNodeReport.inconclusiveReason`, but the routing decision
+ * is yours and yours alone.
  */
 export interface FSLivenessDetectionNode extends FSNodeBase {
   type: FSNodeType.LIVENESS_DETECTION

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -5,6 +5,13 @@ export enum WebhookType {
   MEDIA_USER_VIDEO = "media.user_video",
   ANALYSIS_VIDEO = "analysis.video",
   ANALYSIS_SCREENSHOT = "analysis.screenshot",
+  /**
+   * Post-session deepfake analysis reached a terminal state (succeeded, failed
+   * or timed out). Doorbell-only, like every other webhook here: the event
+   * carries no verdict — refetch the session and read
+   * `SessionReport.deepfakeDetectionStatus` and `SessionReport.deepfakeDetection`.
+   */
+  ANALYSIS_DEEPFAKE = "analysis.deepfake",
   SETTINGS_AVATARS = "settings.avatars",
   SETTINGS_LANGS = "settings.langs",
 }

--- a/test/customization.test.ts
+++ b/test/customization.test.ts
@@ -1,0 +1,87 @@
+import nodeFetch from "node-fetch"
+import Client from "../src/client"
+import {
+  FSLivenessDetectionOutcome,
+  FSNode,
+  FSNodeType,
+  SessionSettings,
+} from "../src/api-endpoints"
+
+jest.mock("node-fetch", () => jest.fn())
+
+const mockFetch = nodeFetch as unknown as jest.Mock
+
+const flow: FSNode[] = [
+  { id: "start", type: FSNodeType.START, outcome: "liveness" },
+  {
+    id: "liveness",
+    type: FSNodeType.LIVENESS_DETECTION,
+    outcomes: {
+      [FSLivenessDetectionOutcome.LIVENESS_DETECTED]: "end",
+      [FSLivenessDetectionOutcome.DEEPFAKE_DETECTED]: "end",
+      [FSLivenessDetectionOutcome.NO_FACE]: "end",
+      [FSLivenessDetectionOutcome.INCONCLUSIVE]: "end",
+    },
+  },
+  { id: "end", type: FSNodeType.END },
+]
+
+const createSession = async (settings: Partial<SessionSettings>) => {
+  const client = new Client({ auth: "sk_test_key" })
+  await client.session.create({ metadata: {}, flow, ...settings })
+
+  const [, init] = mockFetch.mock.calls[0]
+  return JSON.parse(init.body as string) as SessionSettings
+}
+
+describe("createSession customization pass-through", () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () =>
+        JSON.stringify({
+          session: { id: "sess_1", createdAt: 0, status: "created" },
+          clientSecret: { secret: "cs_1", expiresAt: 0 },
+        }),
+    })
+  })
+
+  it("omits customization entirely when it is not set", async () => {
+    const body = await createSession({})
+
+    expect(body.customization).toBeUndefined()
+    expect("customization" in body).toBe(false)
+  })
+
+  it("sends captionsOpenedByDefault: false as-is", async () => {
+    const body = await createSession({
+      customization: { controls: { captionsOpenedByDefault: false } },
+    })
+
+    expect(body.customization?.controls?.captionsOpenedByDefault).toBe(false)
+  })
+
+  it("sends captionsOpenedByDefault: true as-is", async () => {
+    const body = await createSession({
+      customization: { controls: { captionsOpenedByDefault: true } },
+    })
+
+    expect(body.customization?.controls?.captionsOpenedByDefault).toBe(true)
+  })
+
+  it("keeps captionsOpenedByDefault alongside showUxControls", async () => {
+    const body = await createSession({
+      customization: {
+        controls: { showUxControls: true, captionsOpenedByDefault: true },
+      },
+    })
+
+    expect(body.customization?.controls).toEqual({
+      showUxControls: true,
+      captionsOpenedByDefault: true,
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,8 @@
     "noPropertyAccessFromIndexSignature": true,
     "forceConsistentCasingInFileNames": true,
     "typeRoots": ["./node_modules/@types"]
-  }
+  },
 
-  // "include": ["src/**/*"]
+  // Tests are compiled by ts-jest, never emitted into the published build.
+  "exclude": ["build", "node_modules", "test"]
 }


### PR DESCRIPTION
One release for the whole batch, per the agreed "one release, one deploy per repo".

## Task 1 — optional closed captions

`ControlsCustomization.captionsOpenedByDefault`. `true` opens the transcript panel at session start; omitted or `false` keeps today's closed state. The user can still toggle it with the CC button. Documented as inapplicable when `showUxControls` is `false` — that is the master switch for the whole control panel.

## Task 2 — inconclusive liveness outcome (breaking)

`FSLivenessDetectionOutcome` gains `INCONCLUSIVE`. Because `outcomes` is a total map, **every flow builder on this version must supply the edge**. An inconclusive check means the detector produced no verdict — it could not decide, did not run, or there was nothing to analyse. It is a failure of the check, not of the user, and where it routes is now the flow author's decision instead of ours.

Flows submitted without the edge are not rejected: `facesign-ff` fills it from the node's `noFace` target, records it in `SessionSettings.flowNormalizations` and reports it in `CreateSessionResponse.warnings`.

Also adds `LivenessDetectionNodeReport.inconclusiveReason`, `DeepfakeDetectionStatus` + `SessionReport.deepfakeDetectionStatus`, and `WebhookType.ANALYSIS_DEEPFAKE`.

## Tests

The repo declared `jest ./test` but had no config and no tests. Adds `jest.config.js` and `test/customization.test.ts`, covering the captions field for omitted / `false` / `true` through the real `pick(args, bodyParams)` path rather than only type-checking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)